### PR TITLE
ml - allow optional params in rake task

### DIFF
--- a/lib/be_strong/rails/tasks.rake
+++ b/lib/be_strong/rails/tasks.rake
@@ -1,7 +1,14 @@
 namespace :be_strong do
   desc 'Apply strong parameter method and remove attr_accessible, attr_protected.'
-  task convert: :environment do
-    result = BeStrong::Converter.convert
+  task convert: :environment do |task, args|
+    params = {}
+    if args.extras.count >= 1
+      params[:controller_path] = args.extras[0]
+    end
+    if args.extras.count >= 2
+      params[:model_path] = args.extras[1]
+    end
+    result = BeStrong::Converter.convert(params)
     result[:applied].each{|file| puts "Apply strong parameter: #{file}"}
     result[:removed].each{|file| puts "Remove attr_[accessible|protected]: #{file}"}
   end


### PR DESCRIPTION
Example usages:
rake be_strong:convert
rake be_strong:convert['app/services']
rake be_strong:convert['engines/my_engine/app/controllers','engines/my_engine/app/models']